### PR TITLE
Add python bs4 module

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -4,7 +4,7 @@ LABEL maintainer="Bastian Kleinschmidt <debaschdi@googlemail.com>" \
       org.label-schema.docker.dockerfile="/Dockerfile" \
       org.label-schema.name="docker.new-easyepg"
 
-ARG DEPENDENCIES="git ca-certificates python3 python3-pip python3-simplejson python3-requests python3-bottle python3-xmltodict"
+ARG DEPENDENCIES="git ca-certificates python3 python3-pip python3-simplejson python3-requests python3-bottle python3-xmltodict python3-bs4"
 
 ENV USER_ID="99" \
     GROUP_ID="100" \

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -4,7 +4,7 @@ LABEL maintainer="Bastian Kleinschmidt <debaschdi@googlemail.com>" \
       org.label-schema.docker.dockerfile="/Dockerfile" \
       org.label-schema.name="docker.new-easyepg"
 
-ARG DEPENDENCIES="git ca-certificates python3 python3-pip python3-simplejson python3-requests python3-bottle python3-xmltodict"
+ARG DEPENDENCIES="git ca-certificates python3 python3-pip python3-simplejson python3-requests python3-bottle python3-xmltodict python3-bs4"
 
 ENV USER_ID="99" \
     GROUP_ID="100" \

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -4,7 +4,7 @@ LABEL maintainer="Bastian Kleinschmidt <debaschdi@googlemail.com>" \
       org.label-schema.docker.dockerfile="/Dockerfile" \
       org.label-schema.name="docker.new-easyepg"
 
-ARG DEPENDENCIES="git ca-certificates python3 python3-pip python3-simplejson python3-requests python3-bottle python3-xmltodict"
+ARG DEPENDENCIES="git ca-certificates python3 python3-pip python3-simplejson python3-requests python3-bottle python3-xmltodict python3-bs4"
 
 ENV USER_ID="99" \
     GROUP_ID="100" \


### PR DESCRIPTION
To fix errors with newer versions of script.service.easyepg-lite, add the Python3-bs4 module to the dependencies.